### PR TITLE
Refactor to use a single bucket

### DIFF
--- a/groups/data-lake/buckets.tf
+++ b/groups/data-lake/buckets.tf
@@ -4,14 +4,16 @@ resource "aws_s3_bucket" "data_lake" {
   acl    = "private"
 }
 
-# terraform-runner -g data-lake -c import -p development-eu-west-2 -- aws_s3_bucket.data_lake_glue_temporary aws-glue-temporary-169942020521-eu-west-2
-resource "aws_s3_bucket" "data_lake_glue_temporary" {
-  bucket = local.glue_temporary_bucket_name
+resource "aws_s3_bucket_object" "glue_scripts" {
+  bucket = aws_s3_bucket.data_lake.id
   acl    = "private"
+  key    = "${local.glue_scripts_bucket_path}/"
+  source = "/dev/null"
 }
 
-# terraform-runner -g data-lake -c import -p development-eu-west-2 -- aws_s3_bucket.data_lake_glue_scripts aws-glue-scripts-169942020521-eu-west-2
-resource "aws_s3_bucket" "data_lake_glue_scripts" {
-  bucket = local.glue_scripts_bucket_name
+resource "aws_s3_bucket_object" "glue_temporary" {
+  bucket = aws_s3_bucket.data_lake.id
   acl    = "private"
+  key    = "${local.glue_temporary_bucket_path}/"
+  source = "/dev/null"
 }

--- a/groups/data-lake/buckets.tf
+++ b/groups/data-lake/buckets.tf
@@ -1,6 +1,6 @@
 # terraform-runner -g data-lake -c import -p development-eu-west-2 -- aws_s3_bucket.data_lake aws-glue-datalakepre-london
 resource "aws_s3_bucket" "data_lake" {
-  bucket = local.bucket
+  bucket = local.bucket_name
   acl    = "private"
 }
 

--- a/groups/data-lake/glue.tf
+++ b/groups/data-lake/glue.tf
@@ -55,11 +55,11 @@ resource "aws_glue_job" "data" {
   connections = [aws_glue_connection.data.name]
 
   command {
-    script_location = "s3://${local.glue_scripts_bucket_name}%{ if local.glue_scripts_bucket_path != "" }/${local.glue_scripts_bucket_path}%{ endif }/redshift_load_from_s3_deletefirst_v2"
+    script_location = "s3://${local.bucket_name}/${local.glue_scripts_bucket_path}/redshift_load_from_s3_deletefirst_v2"
   }
 
   default_arguments = {
-    "--TempDir"             = "s3://${local.glue_temporary_bucket_name}%{ if local.glue_temporary_bucket_path != "" }/${local.glue_temporary_bucket_path}%{ endif }"
+    "--TempDir"             = "s3://${local.bucket_name}/${local.glue_temporary_bucket_path}"
     "--job-bookmark-option" = "job-bookmark-disable"
     "--job-language"        = "python"
   }

--- a/groups/data-lake/locals.tf
+++ b/groups/data-lake/locals.tf
@@ -3,7 +3,7 @@ data "vault_generic_secret" "secrets" {
 }
 
 locals {
-  bucket                                = data.vault_generic_secret.secrets.data.bucket
+  bucket_name                           = data.vault_generic_secret.secrets.data.bucket_name
   glue_availability_zone                = data.vault_generic_secret.secrets.data.glue_availability_zone
   glue_catalog_database                 = data.vault_generic_secret.secrets.data.glue_catalog_database
   glue_scripts_bucket_name              = data.vault_generic_secret.secrets.data.glue_scripts_bucket_name

--- a/groups/data-lake/locals.tf
+++ b/groups/data-lake/locals.tf
@@ -6,10 +6,8 @@ locals {
   bucket_name                           = data.vault_generic_secret.secrets.data.bucket_name
   glue_availability_zone                = data.vault_generic_secret.secrets.data.glue_availability_zone
   glue_catalog_database                 = data.vault_generic_secret.secrets.data.glue_catalog_database
-  glue_scripts_bucket_name              = data.vault_generic_secret.secrets.data.glue_scripts_bucket_name
   glue_scripts_bucket_path              = data.vault_generic_secret.secrets.data.glue_scripts_bucket_path
   glue_subnet_id                        = data.vault_generic_secret.secrets.data.glue_subnet_id
-  glue_temporary_bucket_name            = data.vault_generic_secret.secrets.data.glue_temporary_bucket_name
   glue_temporary_bucket_path            = data.vault_generic_secret.secrets.data.glue_temporary_bucket_path
   mongo_db_security_group_tag_filter    = data.vault_generic_secret.secrets.data.mongo_db_security_group_tag_filter
   mongo_export_collection               = data.vault_generic_secret.secrets.data.mongo_export_collection

--- a/groups/data-lake/policies-and-roles.tf
+++ b/groups/data-lake/policies-and-roles.tf
@@ -81,16 +81,14 @@ data "aws_iam_policy_document" "data_lake_glue" {
 
   statement {
 
-    sid = "ListAccessToDataLakeBuckets"
+    sid = "ListAccessToDataLakeBucket"
 
     actions = [
       "s3:ListBucket"
     ]
 
     resources = [
-      "${aws_s3_bucket.data_lake.arn}",
-      "${aws_s3_bucket.data_lake_glue_temporary.arn}",
-      "${aws_s3_bucket.data_lake_glue_scripts.arn}",
+      "${aws_s3_bucket.data_lake.arn}"
     ]
   }
 
@@ -104,9 +102,7 @@ data "aws_iam_policy_document" "data_lake_glue" {
     ]
 
     resources = [
-      "${aws_s3_bucket.data_lake.arn}/*",
-      "${aws_s3_bucket.data_lake_glue_temporary.arn}/*",
-      "${aws_s3_bucket.data_lake_glue_scripts.arn}/*"
+      "${aws_s3_bucket.data_lake.arn}/*"
     ]
   }
 }


### PR DESCRIPTION
Remove the script and temporary buckets. Explicitly create bucket
folders for the glue scripts and temporary location. Update the glue
configuration accordingly. There is no validation on this value as yet
so care will need to be taken. Remove unused vault lookups. Update
policies as required

Resolves: DVOP-1610