### PR TITLE
Enable encryption, audit logging and set snapshot retention to 7 days

### DIFF
--- a/groups/data-lake/lambdas.tf
+++ b/groups/data-lake/lambdas.tf
@@ -7,6 +7,7 @@ resource "aws_lambda_function" "mongo_export" {
   role          = aws_iam_role.mongo_export.arn
   runtime       = "nodejs10.x"
   timeout       = 303
+  memory_size   = var.lambda_memory_size
 
   vpc_config {
     subnet_ids         = split(",", local.mongo_export_subnet_ids)

--- a/groups/data-lake/profiles/live-eu-west-2/common-eu-west-2/vars
+++ b/groups/data-lake/profiles/live-eu-west-2/common-eu-west-2/vars
@@ -1,0 +1,1 @@
+lambda_memory_size = 512

--- a/groups/data-lake/providers.tf
+++ b/groups/data-lake/providers.tf
@@ -1,3 +1,4 @@
 provider "aws" {
   region = var.region
+  version = "< 5"
 }

--- a/groups/data-lake/providers.tf
+++ b/groups/data-lake/providers.tf
@@ -1,4 +1,4 @@
 provider "aws" {
-  region = var.region
+  region  = var.region
   version = "< 5"
 }

--- a/groups/data-lake/redshift.tf
+++ b/groups/data-lake/redshift.tf
@@ -14,11 +14,20 @@ resource "aws_redshift_cluster" "data" {
 
   publicly_accessible = false
   skip_final_snapshot = true
+  encrypted           = true
 
   cluster_subnet_group_name = aws_redshift_subnet_group.data.name
   database_name = local.redshift_database_name
 
+  automated_snapshot_retention_period = 7
+
   vpc_security_group_ids = [aws_security_group.data.id]
+
+  logging {
+    enable               = true
+    log_destination_type = "cloudwatch"
+    log_exports          = ["connectionlog", "userlog"]
+  }
 
   depends_on = [
     aws_security_group.data

--- a/groups/data-lake/variables.tf
+++ b/groups/data-lake/variables.tf
@@ -24,3 +24,9 @@ variable "service" {
   description = "The service name to be used when creating AWS resources"
   default     = "data-lake"
 }
+
+variable "lambda_memory_size" {
+  type        = number
+  description = "The maximum memory size to allocate to the lambda"
+  default     = 128
+}


### PR DESCRIPTION
Enables encryption at rest, audit logging to cloudwatch and sets the snapshot retention period to 7 days.

Also sets the lambda memory size to 512 MB in ch-live to match the value currently configured there.


Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2785